### PR TITLE
use github workflows to build archiso

### DIFF
--- a/.github/workflows/BuildArchIso.yml
+++ b/.github/workflows/BuildArchIso.yml
@@ -1,0 +1,49 @@
+name: Build Arch ISO
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    - name: Build In Docker
+      run: |
+        cat << EOF > entrypoint.sh
+        cd /build
+        useradd builduser -m
+        passwd -d builduser
+        pacman -Syu --noconfirm --needed sudo git base-devel
+        printf 'builduser ALL=(ALL) ALL\\n' | tee -a /etc/sudoers
+        chown -R builduser:builduser ./
+        sudo -u builduser bash -c './prepare.sh'
+        sudo -u builduser bash -c './build.sh'
+        EOF
+
+        docker run --privileged -t -v $PWD:/build archlinux /bin/bash /build/entrypoint.sh
+    
+    - name: Upload Built ISO
+      if: ${{ github.ref == 'refs/heads/senpai' && !contains(github.event.head_commit.message, '[no rel]') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: built-iso
+        path: ${{ github.workspace }}/out/archlinux-t2mac-*.iso
+    - name: Create Tag
+      id: create_tag
+      if: ${{ github.ref == 'refs/heads/senpai' && !contains(github.event.head_commit.message, '[no rel]') }}
+      run: |
+        export TAG=$(date +%Y.%m.%d)
+        echo "::set-output name=tag::${TAG}"
+        echo $TAG
+    - name: Release
+      if: ${{ github.ref == 'refs/heads/senpai' && !contains(github.event.head_commit.message, '[no rel]') }}
+      uses: softprops/action-gh-release@v1
+      with:
+         files: |
+           ${{ github.workspace }}/out/archlinux-t2mac-*.iso
+         tag_name: ${{ steps.create_tag.outputs.tag }}
+         draft: ${{ contains(github.event.head_commit.message, '[draft]') }}
+         prerelease: ${{ contains(github.event.head_commit.message, '[prerel]') }}
+         body: |
+           Follow [this](https://wiki.t2linux.org/distributions/arch/installation/) guide using this ISO to install Arch on your T2 Mac 
+      env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo pacman --noconfirm --needed -S archiso wget
 cd firmware
-makepkg -s
+makepkg -s --noconfirm
 mkdir ../archiso/airootfs/t2kern/
 cp *.pkg.* ../archiso/airootfs/t2kern/
 cd ../archiso/airootfs/t2kern/


### PR DESCRIPTION
This sets up github to automatically build pushes to the `senpai` branch and create releases with. [This release](https://github.com/brad/archiso-t2/releases/tag/2022.02.05) is an example (and it includes the archiso releng updates from #4)